### PR TITLE
Pages: Add statement about Node support policy

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -32,6 +32,9 @@ QUnit.test( "hello test", function( assert ) {
 	<h3>Browser Support</h3>
 	<p>QUnit currently supports <a href="https://jquery.com/browser-support/" target="_blank">the same browsers as jQuery 3.x</a>.</p>
 	<p>For legacy browser support, including Internet Explorer versions lower than IE9, please use the 1.x series of QUnit.</p>
+
+	<h3>Node Support</h3>
+	<p>QUnit follows the <a href="https://github.com/nodejs/LTS" target="_blank">Node Long-term Support (LTS) Schedule</a>. Support is provided for Current, Active, and Maintenance releases.</p>
 </div>
 
 <div class="six columns">


### PR DESCRIPTION
Formalizing some things we've discussed, such as in https://github.com/qunitjs/qunit/issues/1067.

Hoping to align on something similar to [Ember's current policy](http://emberjs.com/blog/2016/09/07/ember-node-lts-support.html), which basically just follows the Node LTS schedule.