### PR TITLE
Plugins: Add qunit-puppeteer-reporter

### DIFF
--- a/pages/plugins.html
+++ b/pages/plugins.html
@@ -37,7 +37,8 @@
 <ul>
 	<li><a href="https://github.com/jonkemp/qunit-phantomjs-runner">QUnit PhantomJS Runner</a> - A PhantomJS-powered headless test runner, providing basic console output for QUnit tests.</li>
 	<li><a href="https://github.com/davidtaylorhq/qunit-puppeteer">QUnit Puppeteer Runner</a> - A Puppeteer-powered (headless Chromium) test runner, providing basic console output for QUnit tests</li>
-	<li><a href="https://github.com/ameshkov/node-qunit-puppeteer">Node QUnit Puppeteer</a> - A simple node module for running qunit tests with headless Chromium.</li>
+	<li><a href="https://github.com/ameshkov/node-qunit-puppeteer">Node QUnit Puppeteer</a> - A simple Node module for running qunit tests with headless Chromium</li>
+	<li><a href="https://github.com/FND/qunit-puppeteer-reporter">qunit-puppeteer-reporter</a> - A minimal wrapper for headless browser testing</li>
 	<li><a href="https://github.com/JamesMGreene/qunit-composite">Composite</a> - bundle multiple test suites into a single file, running them in an <code>iframe</code></li>
 	<li><a href="https://github.com/JamesMGreene/qunit-reporter-junit">JUnit Reporter</a> - produces JUnit-style XML output for test results, for integration into tools like Jenkins</li>
 	<li><a href="https://github.com/mkrisher/qunit_for_rails">Rails plugin for QUnit integration</a></li>


### PR DESCRIPTION
I was struggling with @ameshkov's Puppeteer wrapper, so resorted to writing my own. It's intentionally more simplistic than both known alternatives, focusing only on success/failure reporting: https://github.com/FND/qunit-puppeteer-reporter