### PR TITLE
Mention eslint-plugin-qunit in intro doc

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -86,6 +86,10 @@ Prior to QUnit 2.4.1, the npm package was published under the name "qunit**js**"
 
 The 0.x and 1.x versions of the "qunit" package on npm holds an alternative CLI that is now published as [node-qunit](https://github.com/qunitjs/node-qunit).
 
+### Linting
+
+The [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit) package has a variety of rules available for enforcing best testing practices as well as detecting broken tests.
+
 ---
 
 ## In the Browser


### PR DESCRIPTION
Fixes #174.

This spot in the doc doesn't have to be the final resting place for this call-out, but I think it's important we start getting visibility for [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit).

eslint-plugin-qunit is a popular and mature linting plugin for enforcing best testing practices and autofixing common mistakes with QUnit tests. It can help improve test quality as well as improve the developer experience of using QUnit.